### PR TITLE
feat: add OAuth 2.0 authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,18 @@ go 1.24.0
 
 require (
 	github.com/fatih/color v1.18.0
+	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.34.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -9,6 +12,11 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"github.com/open-cli-collective/salesforce-cli/internal/config"
+	"github.com/open-cli-collective/salesforce-cli/internal/keychain"
+)
+
+const (
+	// DefaultCallbackPort is the port for the OAuth callback server
+	DefaultCallbackPort = 8080
+
+	// ProductionLoginURL is the Salesforce production login endpoint
+	ProductionLoginURL = "https://login.salesforce.com"
+
+	// SandboxLoginURL is the Salesforce sandbox login endpoint
+	SandboxLoginURL = "https://test.salesforce.com"
+)
+
+// Scopes contains the OAuth scopes required by the CLI
+var Scopes = []string{
+	"api",
+	"refresh_token",
+	"offline_access",
+}
+
+// GetOAuthConfig creates an OAuth2 config for Salesforce.
+// instanceURL should be the Salesforce login URL (e.g., login.salesforce.com or custom domain).
+func GetOAuthConfig(instanceURL, clientID string) *oauth2.Config {
+	// Normalize instance URL
+	instanceURL = normalizeInstanceURL(instanceURL)
+
+	return &oauth2.Config{
+		ClientID: clientID,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  instanceURL + "/services/oauth2/authorize",
+			TokenURL: instanceURL + "/services/oauth2/token",
+		},
+		RedirectURL: fmt.Sprintf("http://localhost:%d/callback", DefaultCallbackPort),
+		Scopes:      Scopes,
+	}
+}
+
+// GetHTTPClient returns an HTTP client with OAuth2 authentication.
+// It retrieves tokens from keychain (preferred) or falls back to file storage.
+// Returns an error if no token is found - caller should direct user to run 'sfdc init'.
+func GetHTTPClient(ctx context.Context) (*http.Client, error) {
+	// Load config to get instance URL and client ID
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.InstanceURL == "" || cfg.ClientID == "" {
+		return nil, fmt.Errorf("not configured - please run 'sfdc init' first")
+	}
+
+	// Get OAuth config
+	oauthConfig := GetOAuthConfig(cfg.InstanceURL, cfg.ClientID)
+
+	// Try to load token from keychain
+	tok, err := keychain.GetToken()
+	if err != nil {
+		return nil, fmt.Errorf("no OAuth token found - please run 'sfdc init' first: %w", err)
+	}
+
+	// Create persistent token source that saves refreshed tokens
+	tokenSource := keychain.NewPersistentTokenSource(oauthConfig, tok)
+	return oauth2.NewClient(ctx, tokenSource), nil
+}
+
+// GetAuthURL returns the OAuth authorization URL for the given config.
+func GetAuthURL(config *oauth2.Config) string {
+	return config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+}
+
+// ExchangeAuthCode exchanges an authorization code for a token.
+func ExchangeAuthCode(ctx context.Context, config *oauth2.Config, code string) (*oauth2.Token, error) {
+	return config.Exchange(ctx, code)
+}
+
+// normalizeInstanceURL ensures the instance URL has proper format.
+func normalizeInstanceURL(url string) string {
+	url = strings.TrimSpace(url)
+
+	// Add https:// if no scheme provided
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		url = "https://" + url
+	}
+
+	// Remove trailing slash
+	url = strings.TrimSuffix(url, "/")
+
+	return url
+}
+
+// IsProductionURL returns true if the URL is the production login URL.
+func IsProductionURL(url string) bool {
+	normalized := normalizeInstanceURL(url)
+	return normalized == ProductionLoginURL
+}
+
+// IsSandboxURL returns true if the URL is the sandbox login URL.
+func IsSandboxURL(url string) bool {
+	normalized := normalizeInstanceURL(url)
+	return normalized == SandboxLoginURL
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOAuthConfig(t *testing.T) {
+	config := GetOAuthConfig("https://login.salesforce.com", "test-client-id")
+
+	assert.Equal(t, "test-client-id", config.ClientID)
+	assert.Equal(t, "https://login.salesforce.com/services/oauth2/authorize", config.Endpoint.AuthURL)
+	assert.Equal(t, "https://login.salesforce.com/services/oauth2/token", config.Endpoint.TokenURL)
+	assert.Equal(t, "http://localhost:8080/callback", config.RedirectURL)
+	assert.Contains(t, config.Scopes, "api")
+	assert.Contains(t, config.Scopes, "refresh_token")
+}
+
+func TestGetOAuthConfig_CustomDomain(t *testing.T) {
+	config := GetOAuthConfig("mycompany.my.salesforce.com", "test-client-id")
+
+	assert.Equal(t, "https://mycompany.my.salesforce.com/services/oauth2/authorize", config.Endpoint.AuthURL)
+	assert.Equal(t, "https://mycompany.my.salesforce.com/services/oauth2/token", config.Endpoint.TokenURL)
+}
+
+func TestNormalizeInstanceURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"login.salesforce.com", "https://login.salesforce.com"},
+		{"https://login.salesforce.com", "https://login.salesforce.com"},
+		{"https://login.salesforce.com/", "https://login.salesforce.com"},
+		{"test.salesforce.com", "https://test.salesforce.com"},
+		{"mycompany.my.salesforce.com", "https://mycompany.my.salesforce.com"},
+		{"  login.salesforce.com  ", "https://login.salesforce.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeInstanceURL(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsProductionURL(t *testing.T) {
+	assert.True(t, IsProductionURL("login.salesforce.com"))
+	assert.True(t, IsProductionURL("https://login.salesforce.com"))
+	assert.False(t, IsProductionURL("test.salesforce.com"))
+	assert.False(t, IsProductionURL("mycompany.my.salesforce.com"))
+}
+
+func TestIsSandboxURL(t *testing.T) {
+	assert.True(t, IsSandboxURL("test.salesforce.com"))
+	assert.True(t, IsSandboxURL("https://test.salesforce.com"))
+	assert.False(t, IsSandboxURL("login.salesforce.com"))
+	assert.False(t, IsSandboxURL("mycompany.my.salesforce.com"))
+}
+
+func TestGetAuthURL(t *testing.T) {
+	config := GetOAuthConfig("https://login.salesforce.com", "test-client-id")
+	url := GetAuthURL(config)
+
+	assert.Contains(t, url, "https://login.salesforce.com/services/oauth2/authorize")
+	assert.Contains(t, url, "client_id=test-client-id")
+	assert.Contains(t, url, "redirect_uri=")
+	assert.Contains(t, url, "response_type=code")
+}

--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// CallbackResult contains the result of an OAuth callback.
+type CallbackResult struct {
+	Code  string
+	Error string
+}
+
+// StartCallbackServer starts a local HTTP server to receive the OAuth callback.
+// Returns a channel that will receive the authorization code or error.
+func StartCallbackServer(ctx context.Context, port int) (<-chan CallbackResult, error) {
+	resultChan := make(chan CallbackResult, 1)
+
+	// Check if port is available
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("failed to start callback server on port %d: %w", port, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		errMsg := r.URL.Query().Get("error")
+		errDesc := r.URL.Query().Get("error_description")
+
+		if errMsg != "" {
+			msg := errMsg
+			if errDesc != "" {
+				msg = fmt.Sprintf("%s: %s", errMsg, errDesc)
+			}
+			resultChan <- CallbackResult{Error: msg}
+
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<!DOCTYPE html>
+<html>
+<head><title>Authentication Failed</title></head>
+<body>
+<h1>Authentication Failed</h1>
+<p>Error: %s</p>
+<p>You can close this window.</p>
+</body>
+</html>`, msg)
+			return
+		}
+
+		if code == "" {
+			resultChan <- CallbackResult{Error: "no authorization code received"}
+
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<!DOCTYPE html>
+<html>
+<head><title>Authentication Failed</title></head>
+<body>
+<h1>Authentication Failed</h1>
+<p>No authorization code received.</p>
+<p>You can close this window.</p>
+</body>
+</html>`)
+			return
+		}
+
+		resultChan <- CallbackResult{Code: code}
+
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!DOCTYPE html>
+<html>
+<head><title>Authentication Successful</title></head>
+<body>
+<h1>Authentication Successful!</h1>
+<p>You can close this window and return to the terminal.</p>
+</body>
+</html>`)
+	})
+
+	server := &http.Server{
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+
+	// Start server in goroutine
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			resultChan <- CallbackResult{Error: fmt.Sprintf("callback server error: %v", err)}
+		}
+	}()
+
+	// Shutdown server when context is cancelled or result is received
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-resultChan:
+		}
+		// Give a moment for the response to be sent
+		time.Sleep(100 * time.Millisecond)
+		_ = server.Close()
+	}()
+
+	return resultChan, nil
+}

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -1,0 +1,24 @@
+// Package auth provides OAuth 2.0 authentication for Salesforce.
+package auth
+
+import (
+	"github.com/open-cli-collective/salesforce-cli/internal/config"
+)
+
+// GetCredentialsPath returns the full path to the config file.
+// Re-exported from config package for convenience.
+func GetCredentialsPath() (string, error) {
+	return config.GetConfigPath()
+}
+
+// GetTokenPath returns the full path to the token file (fallback storage).
+// Re-exported from config package for convenience.
+func GetTokenPath() (string, error) {
+	return config.GetTokenPath()
+}
+
+// ShortenPath replaces the home directory prefix with ~ for display.
+// Re-exported from config package for convenience.
+func ShortenPath(path string) string {
+	return config.ShortenPath(path)
+}

--- a/internal/cmd/configcmd/configcmd.go
+++ b/internal/cmd/configcmd/configcmd.go
@@ -1,0 +1,231 @@
+// Package configcmd provides the config command and subcommands.
+package configcmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/salesforce-cli/internal/auth"
+	"github.com/open-cli-collective/salesforce-cli/internal/config"
+	"github.com/open-cli-collective/salesforce-cli/internal/keychain"
+)
+
+// NewCommand returns the config command with subcommands.
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage configuration",
+		Long:  "View, test, and manage Salesforce CLI configuration.",
+	}
+
+	cmd.AddCommand(newShowCommand())
+	cmd.AddCommand(newTestCommand())
+	cmd.AddCommand(newClearCommand())
+
+	return cmd
+}
+
+func newShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Display current configuration",
+		Long:  "Display the current Salesforce CLI configuration including instance URL and token storage.",
+		Args:  cobra.NoArgs,
+		RunE:  runShow,
+	}
+}
+
+func newTestCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "test",
+		Short: "Verify authentication works",
+		Long:  "Test the current OAuth token by making a request to the Salesforce API.",
+		Args:  cobra.NoArgs,
+		RunE:  runTest,
+	}
+}
+
+func newClearCommand() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Remove stored credentials",
+		Long:  "Remove all stored credentials and configuration. This will require re-authentication.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runClear(force)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runShow(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	fmt.Println("Salesforce CLI Configuration")
+	fmt.Println("============================")
+	fmt.Println()
+
+	// Instance URL
+	if cfg.InstanceURL != "" {
+		fmt.Printf("Instance URL:    %s\n", cfg.InstanceURL)
+	} else {
+		fmt.Println("Instance URL:    Not configured")
+	}
+
+	// Client ID (show partial for security)
+	if cfg.ClientID != "" {
+		masked := maskClientID(cfg.ClientID)
+		fmt.Printf("Client ID:       %s\n", masked)
+	} else {
+		fmt.Println("Client ID:       Not configured")
+	}
+
+	// Token status
+	fmt.Println()
+	if keychain.HasStoredToken() {
+		fmt.Printf("Token:           Found (stored in %s)\n", keychain.GetStorageBackend())
+	} else {
+		fmt.Println("Token:           Not found")
+	}
+
+	// Config file location
+	fmt.Println()
+	configPath, err := config.GetConfigPath()
+	if err != nil {
+		configPath = "(unable to determine)"
+	}
+	fmt.Printf("Config file:     %s\n", configPath)
+
+	return nil
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	if cfg.InstanceURL == "" || cfg.ClientID == "" {
+		return fmt.Errorf("not configured - please run 'sfdc init' first")
+	}
+
+	fmt.Println("Testing Salesforce connection...")
+	fmt.Println()
+
+	// Check token exists
+	if !keychain.HasStoredToken() {
+		fmt.Println("  Token:       NOT FOUND")
+		return fmt.Errorf("no OAuth token found - please run 'sfdc init' first")
+	}
+	fmt.Println("  Token:       Found")
+
+	// Get authenticated client
+	ctx := context.Background()
+	client, err := auth.GetHTTPClient(ctx)
+	if err != nil {
+		fmt.Println("  OAuth:       FAILED")
+		return fmt.Errorf("failed to create OAuth client: %w", err)
+	}
+	fmt.Println("  OAuth:       OK")
+
+	// Test API access
+	normalizedURL := normalizeURL(cfg.InstanceURL)
+	resp, err := client.Get(normalizedURL + "/services/data/")
+	if err != nil {
+		fmt.Println("  API:         FAILED")
+		return fmt.Errorf("failed to access Salesforce API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("  API:         FAILED")
+		return fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+	fmt.Println("  API:         OK")
+
+	fmt.Println()
+	fmt.Println("Connection successful!")
+	return nil
+}
+
+func runClear(force bool) error {
+	if !force {
+		fmt.Print("This will remove all stored credentials. Continue? [y/N]: ")
+		var response string
+		_, _ = fmt.Scanln(&response)
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	var hadToken, hadConfig bool
+	var tokenErr, configErr error
+
+	// Clear token from keychain
+	if keychain.HasStoredToken() {
+		hadToken = true
+		tokenErr = keychain.DeleteToken()
+	}
+
+	// Clear config file
+	cfg, _ := config.Load()
+	if cfg.InstanceURL != "" || cfg.ClientID != "" {
+		hadConfig = true
+		cfg.InstanceURL = ""
+		cfg.ClientID = ""
+		configErr = config.Save(cfg)
+	}
+
+	// Report results
+	if tokenErr != nil {
+		fmt.Printf("Warning: failed to remove token: %v\n", tokenErr)
+	} else if hadToken {
+		fmt.Println("Token removed.")
+	}
+
+	if configErr != nil {
+		fmt.Printf("Warning: failed to clear config: %v\n", configErr)
+	} else if hadConfig {
+		fmt.Println("Configuration cleared.")
+	}
+
+	if !hadToken && !hadConfig {
+		fmt.Println("Nothing to clear.")
+	} else if tokenErr == nil && configErr == nil {
+		fmt.Println()
+		fmt.Println("All credentials cleared. Run 'sfdc init' to reconfigure.")
+	}
+
+	return nil
+}
+
+// maskClientID masks a client ID for display, showing only first and last 4 chars.
+func maskClientID(clientID string) string {
+	if len(clientID) <= 12 {
+		return "****"
+	}
+	return clientID[:4] + "..." + clientID[len(clientID)-4:]
+}
+
+// normalizeURL ensures the URL has https:// prefix.
+func normalizeURL(url string) string {
+	url = strings.TrimSpace(url)
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		url = "https://" + url
+	}
+	return strings.TrimSuffix(url, "/")
+}

--- a/internal/cmd/configcmd/configcmd_test.go
+++ b/internal/cmd/configcmd/configcmd_test.go
@@ -1,0 +1,81 @@
+package configcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCommand(t *testing.T) {
+	cmd := NewCommand()
+
+	assert.Equal(t, "config", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	// Check subcommands exist
+	subcommands := cmd.Commands()
+	var subNames []string
+	for _, sub := range subcommands {
+		subNames = append(subNames, sub.Use)
+	}
+
+	assert.Contains(t, subNames, "show")
+	assert.Contains(t, subNames, "test")
+	assert.Contains(t, subNames, "clear")
+}
+
+func TestMaskClientID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "long client ID",
+			input:    "3MVG9nKNqSNYF2dG9y7eJzIxOtLw.abc123xyz",
+			expected: "3MVG...3xyz",
+		},
+		{
+			name:     "short client ID",
+			input:    "short123",
+			expected: "****",
+		},
+		{
+			name:     "exactly 12 chars",
+			input:    "123456789012",
+			expected: "****",
+		},
+		{
+			name:     "13 chars",
+			input:    "1234567890123",
+			expected: "1234...0123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskClientID(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"login.salesforce.com", "https://login.salesforce.com"},
+		{"https://login.salesforce.com", "https://login.salesforce.com"},
+		{"https://login.salesforce.com/", "https://login.salesforce.com"},
+		{"  login.salesforce.com  ", "https://login.salesforce.com"},
+		{"test.salesforce.com", "https://test.salesforce.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeURL(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -1,0 +1,314 @@
+// Package initcmd provides the init command for OAuth setup.
+package initcmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/salesforce-cli/internal/auth"
+	"github.com/open-cli-collective/salesforce-cli/internal/config"
+	"github.com/open-cli-collective/salesforce-cli/internal/keychain"
+)
+
+var (
+	instanceURL string
+	clientID    string
+	noVerify    bool
+	noBrowser   bool
+)
+
+// NewCommand returns the init command.
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Set up Salesforce authentication",
+		Long: `Guided setup for Salesforce OAuth 2.0 authentication.
+
+This command walks you through the OAuth flow with clear instructions.
+After setup, you can use commands like 'sfdc query', etc.
+
+Prerequisites:
+  1. Create a Connected App in Salesforce Setup
+  2. Enable OAuth Settings
+  3. Set Callback URL: http://localhost:8080/callback
+  4. Select scopes: api, refresh_token, offline_access
+  5. Note the Consumer Key (Client ID)`,
+		Args: cobra.NoArgs,
+		RunE: runInit,
+	}
+
+	cmd.Flags().StringVar(&instanceURL, "instance-url", "", "Salesforce instance URL (e.g., login.salesforce.com)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "Connected App Consumer Key")
+	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip connectivity verification after setup")
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Don't auto-open browser, just print URL")
+
+	return cmd
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	reader := bufio.NewReader(os.Stdin)
+
+	// Step 1: Check existing configuration
+	fmt.Println("Checking existing configuration...")
+	cfg, _ := config.Load()
+
+	if keychain.HasStoredToken() {
+		fmt.Printf("Instance URL: %s\n", cfg.InstanceURL)
+		fmt.Printf("Token:        Found (stored in %s)\n", keychain.GetStorageBackend())
+
+		if !noVerify {
+			if err := verifyConnectivity(cfg.InstanceURL); err == nil {
+				fmt.Println()
+				fmt.Println("Already configured and working.")
+				fmt.Println("Use 'sfdc config clear' to reset.")
+				return nil
+			}
+
+			// Token exists but verification failed
+			fmt.Println()
+			fmt.Println("Your OAuth token appears to be expired or revoked.")
+			fmt.Print("Would you like to re-authenticate? [Y/n]: ")
+
+			input, _ := reader.ReadString('\n')
+			input = strings.TrimSpace(strings.ToLower(input))
+			if input != "" && input != "y" && input != "yes" {
+				fmt.Println("You can manually clear the token with: sfdc config clear")
+				return nil
+			}
+
+			fmt.Println("Clearing old token...")
+			if err := keychain.DeleteToken(); err != nil {
+				return fmt.Errorf("failed to clear token: %w", err)
+			}
+		}
+	} else {
+		fmt.Println("Instance URL: Not configured")
+		fmt.Println("Token:        Not found")
+	}
+	fmt.Println()
+
+	// Step 2: Get instance URL
+	if instanceURL == "" {
+		instanceURL = cfg.InstanceURL
+	}
+	if instanceURL == "" {
+		fmt.Println("Salesforce Instance URL")
+		fmt.Println("Enter your Salesforce login URL, or leave blank for production.")
+		fmt.Println()
+		fmt.Println("  Production: login.salesforce.com (default)")
+		fmt.Println("  Sandbox:    test.salesforce.com")
+		fmt.Println("  Custom:     mycompany.my.salesforce.com")
+		fmt.Println()
+		fmt.Print("Instance URL [login.salesforce.com]: ")
+
+		input, _ := reader.ReadString('\n')
+		instanceURL = strings.TrimSpace(input)
+		if instanceURL == "" {
+			instanceURL = "login.salesforce.com"
+		}
+	}
+
+	// Step 3: Get client ID
+	if clientID == "" {
+		clientID = cfg.ClientID
+	}
+	if clientID == "" {
+		fmt.Println()
+		fmt.Println("Connected App Client ID")
+		fmt.Println("Create at: Setup → App Manager → New Connected App")
+		fmt.Println("Required scopes: api, refresh_token, offline_access")
+		fmt.Println("Callback URL: http://localhost:8080/callback")
+		fmt.Println()
+		fmt.Print("Client ID: ")
+
+		input, _ := reader.ReadString('\n')
+		clientID = strings.TrimSpace(input)
+		if clientID == "" {
+			return fmt.Errorf("client ID is required")
+		}
+	}
+
+	// Step 4: Save configuration
+	cfg.InstanceURL = instanceURL
+	cfg.ClientID = clientID
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	// Step 5: Start OAuth flow
+	oauthConfig := auth.GetOAuthConfig(instanceURL, clientID)
+	authURL := auth.GetAuthURL(oauthConfig)
+
+	fmt.Println()
+	if noBrowser {
+		fmt.Println("Open this URL in your browser:")
+	} else {
+		fmt.Println("Opening browser for Salesforce login...")
+		fmt.Println()
+		fmt.Println("If browser doesn't open, visit:")
+	}
+	fmt.Println()
+	fmt.Println(authURL)
+	fmt.Println()
+
+	// Start callback server
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	resultChan, err := auth.StartCallbackServer(ctx, auth.DefaultCallbackPort)
+	if err != nil {
+		fmt.Printf("Warning: Could not start callback server: %v\n", err)
+		fmt.Println("You'll need to manually copy the authorization code.")
+	}
+
+	// Open browser (unless --no-browser)
+	if !noBrowser {
+		if err := openBrowser(authURL); err != nil {
+			fmt.Printf("Could not open browser: %v\n", err)
+		}
+	}
+
+	// Wait for callback or manual input
+	var code string
+	if resultChan != nil {
+		fmt.Println("Waiting for authorization...")
+		fmt.Println("(Or paste the authorization code or full redirect URL below)")
+		fmt.Println()
+
+		// Read from callback or stdin
+		inputChan := make(chan string, 1)
+		go func() {
+			fmt.Print("> ")
+			input, _ := reader.ReadString('\n')
+			inputChan <- strings.TrimSpace(input)
+		}()
+
+		select {
+		case result := <-resultChan:
+			if result.Error != "" {
+				return fmt.Errorf("authorization failed: %s", result.Error)
+			}
+			code = result.Code
+			fmt.Println("Authorization received from callback.")
+		case input := <-inputChan:
+			code = extractAuthCode(input)
+		case <-ctx.Done():
+			return fmt.Errorf("authorization timed out")
+		}
+	} else {
+		fmt.Println("After authorizing, paste the authorization code or full redirect URL:")
+		fmt.Print("> ")
+		input, _ := reader.ReadString('\n')
+		code = extractAuthCode(strings.TrimSpace(input))
+	}
+
+	if code == "" {
+		return fmt.Errorf("no authorization code received")
+	}
+
+	// Step 6: Exchange code for token
+	fmt.Println()
+	fmt.Println("Exchanging authorization code for tokens...")
+
+	token, err := auth.ExchangeAuthCode(ctx, oauthConfig, code)
+	if err != nil {
+		return fmt.Errorf("failed to exchange authorization code: %w", err)
+	}
+
+	// Step 7: Save token
+	if err := keychain.SetToken(token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
+	}
+	fmt.Printf("Token saved to: %s\n", keychain.GetStorageBackend())
+
+	// Step 8: Verify connectivity
+	if !noVerify {
+		fmt.Println()
+		if err := verifyConnectivity(instanceURL); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Setup complete! Try: sfdc query \"SELECT Id, Name FROM Account LIMIT 5\"")
+	return nil
+}
+
+// extractAuthCode extracts the authorization code from user input.
+// It accepts either a full redirect URL or just the code value.
+func extractAuthCode(input string) string {
+	input = strings.TrimSpace(input)
+
+	// If it looks like a URL, try to extract the code parameter
+	if strings.HasPrefix(input, "http://localhost") || strings.HasPrefix(input, "https://localhost") {
+		if u, err := url.Parse(input); err == nil {
+			return u.Query().Get("code")
+		}
+		return ""
+	}
+
+	// Otherwise treat as raw code
+	return input
+}
+
+// verifyConnectivity tests the Salesforce API connection.
+func verifyConnectivity(instanceURL string) error {
+	fmt.Println("Verifying Salesforce API connection...")
+
+	ctx := context.Background()
+	client, err := auth.GetHTTPClient(ctx)
+	if err != nil {
+		fmt.Println("  OAuth token: FAILED")
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	fmt.Println("  OAuth token: OK")
+
+	// Test API access by fetching API versions
+	normalizedURL := "https://" + strings.TrimPrefix(strings.TrimPrefix(instanceURL, "https://"), "http://")
+	resp, err := client.Get(normalizedURL + "/services/data/")
+	if err != nil {
+		fmt.Println("  API access:  FAILED")
+		return fmt.Errorf("failed to access Salesforce API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("  API access:  FAILED")
+		return fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+	fmt.Println("  API access:  OK")
+
+	return nil
+}
+
+// openBrowser opens the default browser to the given URL.
+func openBrowser(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	case "linux":
+		cmd = "xdg-open"
+		args = []string{url}
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start", url}
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+
+	return exec.Command(cmd, args...).Start()
+}

--- a/internal/cmd/initcmd/init_test.go
+++ b/internal/cmd/initcmd/init_test.go
@@ -1,0 +1,67 @@
+package initcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractAuthCode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "raw code",
+			input: "abc123xyz",
+			want:  "abc123xyz",
+		},
+		{
+			name:  "localhost URL with code",
+			input: "http://localhost:8080/callback?code=abc123xyz",
+			want:  "abc123xyz",
+		},
+		{
+			name:  "localhost URL with code and state",
+			input: "http://localhost:8080/callback?code=abc123xyz&state=state-token",
+			want:  "abc123xyz",
+		},
+		{
+			name:  "URL with error",
+			input: "http://localhost:8080/callback?error=access_denied",
+			want:  "",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace",
+			input: "  abc123  ",
+			want:  "abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAuthCode(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewCommand(t *testing.T) {
+	cmd := NewCommand()
+
+	assert.Equal(t, "init", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+
+	// Check flags exist
+	assert.NotNil(t, cmd.Flags().Lookup("instance-url"))
+	assert.NotNil(t, cmd.Flags().Lookup("client-id"))
+	assert.NotNil(t, cmd.Flags().Lookup("no-verify"))
+	assert.NotNil(t, cmd.Flags().Lookup("no-browser"))
+}


### PR DESCRIPTION
## Summary

- Implement OAuth 2.0 Web Server Flow for Salesforce authentication
- Add interactive `init` command for OAuth setup wizard
- Add `config` subcommands (show, test, clear) for configuration management

### Authentication Flow

The `init` command guides users through:
1. Setting instance URL (production, sandbox, or custom domain)
2. Providing Connected App client ID
3. Browser-based OAuth authorization
4. Automatic callback handling or manual code entry
5. Token exchange and secure storage in platform keychain
6. Connection verification

### Config Commands

- `sfdc config show` - Display current configuration and token status
- `sfdc config test` - Verify API connectivity with stored credentials
- `sfdc config clear` - Remove stored credentials and configuration

### Files Added

- `internal/auth/auth.go` - OAuth config, token exchange, HTTP client
- `internal/auth/callback.go` - Local callback server for OAuth redirects
- `internal/auth/config.go` - Re-exports config path helpers
- `internal/cmd/initcmd/init.go` - Interactive OAuth setup wizard
- `internal/cmd/configcmd/configcmd.go` - Config management commands

## Test plan

- [x] `make test` passes with race detection
- [x] `make lint` passes
- [ ] Manual test: `sfdc init` opens browser and completes OAuth flow
- [ ] Manual test: `sfdc config show` displays configuration
- [ ] Manual test: `sfdc config test` verifies API connectivity
- [ ] Manual test: `sfdc config clear` removes credentials

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)