### PR TITLE
feat: add Salesforce REST API client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1,0 +1,338 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// DefaultAPIVersion is the default Salesforce API version
+const DefaultAPIVersion = "v62.0"
+
+// Client is a Salesforce REST API client
+type Client struct {
+	// HTTPClient is the underlying HTTP client (should have OAuth token)
+	HTTPClient *http.Client
+
+	// InstanceURL is the Salesforce instance URL (e.g., https://mycompany.my.salesforce.com)
+	InstanceURL string
+
+	// APIVersion is the API version to use (e.g., v62.0)
+	APIVersion string
+
+	// BaseURL is the full REST API base URL
+	BaseURL string
+}
+
+// ClientConfig contains configuration for creating a new client
+type ClientConfig struct {
+	// InstanceURL is the Salesforce instance URL
+	InstanceURL string
+
+	// HTTPClient is an authenticated HTTP client (e.g., from auth.GetHTTPClient)
+	HTTPClient *http.Client
+
+	// APIVersion is the API version to use (optional, defaults to DefaultAPIVersion)
+	APIVersion string
+}
+
+// New creates a new Salesforce API client
+func New(cfg ClientConfig) (*Client, error) {
+	if cfg.InstanceURL == "" {
+		return nil, ErrInstanceURLRequired
+	}
+	if cfg.HTTPClient == nil {
+		return nil, ErrHTTPClientRequired
+	}
+
+	// Normalize instance URL
+	instanceURL := normalizeURL(cfg.InstanceURL)
+
+	// Use default API version if not specified
+	apiVersion := cfg.APIVersion
+	if apiVersion == "" {
+		apiVersion = DefaultAPIVersion
+	}
+
+	return &Client{
+		HTTPClient:  cfg.HTTPClient,
+		InstanceURL: instanceURL,
+		APIVersion:  apiVersion,
+		BaseURL:     fmt.Sprintf("%s/services/data/%s", instanceURL, apiVersion),
+	}, nil
+}
+
+// normalizeURL ensures the URL has proper format
+func normalizeURL(urlStr string) string {
+	urlStr = strings.TrimSpace(urlStr)
+
+	// Add https:// if no scheme provided
+	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
+		urlStr = "https://" + urlStr
+	}
+
+	// Remove trailing slash
+	return strings.TrimSuffix(urlStr, "/")
+}
+
+// Get performs a GET request to the specified path
+func (c *Client) Get(ctx context.Context, path string) ([]byte, error) {
+	return c.doRequest(ctx, http.MethodGet, path, nil)
+}
+
+// Post performs a POST request to the specified path
+func (c *Client) Post(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	return c.doRequest(ctx, http.MethodPost, path, body)
+}
+
+// Patch performs a PATCH request to the specified path
+func (c *Client) Patch(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	return c.doRequest(ctx, http.MethodPatch, path, body)
+}
+
+// Put performs a PUT request to the specified path
+func (c *Client) Put(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	return c.doRequest(ctx, http.MethodPut, path, body)
+}
+
+// Delete performs a DELETE request to the specified path
+func (c *Client) Delete(ctx context.Context, path string) ([]byte, error) {
+	return c.doRequest(ctx, http.MethodDelete, path, nil)
+}
+
+// doRequest performs an HTTP request
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}) ([]byte, error) {
+	// Build full URL
+	fullURL := c.buildURL(path)
+
+	// Prepare request body
+	var bodyReader io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(jsonBody)
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	// Execute request
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	// Check for errors
+	if resp.StatusCode >= 400 {
+		return nil, ParseAPIError(resp)
+	}
+
+	// Read response body
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return respBody, nil
+}
+
+// buildURL constructs the full URL for an API path
+func (c *Client) buildURL(path string) string {
+	// If path is already absolute, use it directly
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+
+	// If path starts with /services/, it's a full path from instance root
+	if strings.HasPrefix(path, "/services/") {
+		return c.InstanceURL + path
+	}
+
+	// Otherwise, it's relative to the API base URL
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return c.BaseURL + path
+}
+
+// GetAPIVersions returns available API versions
+func (c *Client) GetAPIVersions(ctx context.Context) ([]APIVersion, error) {
+	body, err := c.doRequest(ctx, http.MethodGet, c.InstanceURL+"/services/data/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var versions []APIVersion
+	if err := json.Unmarshal(body, &versions); err != nil {
+		return nil, fmt.Errorf("failed to parse API versions: %w", err)
+	}
+
+	return versions, nil
+}
+
+// GetSObjects returns metadata about all SObjects in the org
+func (c *Client) GetSObjects(ctx context.Context) (*SObjectsResponse, error) {
+	body, err := c.Get(ctx, "/sobjects/")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp SObjectsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse sobjects response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// DescribeSObject returns detailed metadata about an SObject type
+func (c *Client) DescribeSObject(ctx context.Context, objectName string) (*SObjectDescribe, error) {
+	body, err := c.Get(ctx, fmt.Sprintf("/sobjects/%s/describe", objectName))
+	if err != nil {
+		return nil, err
+	}
+
+	var desc SObjectDescribe
+	if err := json.Unmarshal(body, &desc); err != nil {
+		return nil, fmt.Errorf("failed to parse describe response: %w", err)
+	}
+
+	return &desc, nil
+}
+
+// GetLimits returns the org's API limits
+func (c *Client) GetLimits(ctx context.Context) (Limits, error) {
+	body, err := c.Get(ctx, "/limits/")
+	if err != nil {
+		return nil, err
+	}
+
+	var limits Limits
+	if err := json.Unmarshal(body, &limits); err != nil {
+		return nil, fmt.Errorf("failed to parse limits response: %w", err)
+	}
+
+	return limits, nil
+}
+
+// Query executes a SOQL query and returns the results
+func (c *Client) Query(ctx context.Context, soql string) (*QueryResult, error) {
+	path := fmt.Sprintf("/query?q=%s", url.QueryEscape(soql))
+	body, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var result QueryResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse query result: %w", err)
+	}
+
+	return &result, nil
+}
+
+// QueryMore retrieves the next batch of query results
+func (c *Client) QueryMore(ctx context.Context, nextRecordsURL string) (*QueryResult, error) {
+	body, err := c.Get(ctx, nextRecordsURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var result QueryResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse query result: %w", err)
+	}
+
+	return &result, nil
+}
+
+// QueryAll executes a query and retrieves all results (handles pagination)
+func (c *Client) QueryAll(ctx context.Context, soql string) (*QueryResult, error) {
+	result, err := c.Query(ctx, soql)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch additional pages if needed
+	for !result.Done && result.NextRecordsURL != "" {
+		nextPage, err := c.QueryMore(ctx, result.NextRecordsURL)
+		if err != nil {
+			return nil, err
+		}
+		result.Records = append(result.Records, nextPage.Records...)
+		result.Done = nextPage.Done
+		result.NextRecordsURL = nextPage.NextRecordsURL
+	}
+
+	return result, nil
+}
+
+// GetRecord retrieves a single record by ID
+func (c *Client) GetRecord(ctx context.Context, objectName, recordID string, fields []string) (*SObject, error) {
+	path := fmt.Sprintf("/sobjects/%s/%s", objectName, recordID)
+	if len(fields) > 0 {
+		path += "?fields=" + strings.Join(fields, ",")
+	}
+
+	body, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var record SObject
+	if err := json.Unmarshal(body, &record); err != nil {
+		return nil, fmt.Errorf("failed to parse record: %w", err)
+	}
+
+	return &record, nil
+}
+
+// CreateRecord creates a new record and returns the result
+func (c *Client) CreateRecord(ctx context.Context, objectName string, record map[string]interface{}) (*RecordResult, error) {
+	path := fmt.Sprintf("/sobjects/%s/", objectName)
+	body, err := c.Post(ctx, path, record)
+	if err != nil {
+		return nil, err
+	}
+
+	var result RecordResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse create result: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdateRecord updates an existing record
+func (c *Client) UpdateRecord(ctx context.Context, objectName, recordID string, record map[string]interface{}) error {
+	path := fmt.Sprintf("/sobjects/%s/%s", objectName, recordID)
+	_, err := c.Patch(ctx, path, record)
+	return err
+}
+
+// DeleteRecord deletes a record
+func (c *Client) DeleteRecord(ctx context.Context, objectName, recordID string) error {
+	path := fmt.Sprintf("/sobjects/%s/%s", objectName, recordID)
+	_, err := c.Delete(ctx, path)
+	return err
+}
+
+// RecordURL returns the web URL for a record
+func (c *Client) RecordURL(recordID string) string {
+	return fmt.Sprintf("%s/%s", c.InstanceURL, recordID)
+}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,440 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ClientConfig
+		wantErr error
+	}{
+		{
+			name: "valid config",
+			cfg: ClientConfig{
+				InstanceURL: "https://test.salesforce.com",
+				HTTPClient:  http.DefaultClient,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "with custom API version",
+			cfg: ClientConfig{
+				InstanceURL: "https://test.salesforce.com",
+				HTTPClient:  http.DefaultClient,
+				APIVersion:  "v59.0",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "missing instance URL",
+			cfg: ClientConfig{
+				HTTPClient: http.DefaultClient,
+			},
+			wantErr: ErrInstanceURLRequired,
+		},
+		{
+			name: "missing HTTP client",
+			cfg: ClientConfig{
+				InstanceURL: "https://test.salesforce.com",
+			},
+			wantErr: ErrHTTPClientRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := New(tt.cfg)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestClient_NormalizeURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"test.salesforce.com", "https://test.salesforce.com"},
+		{"https://test.salesforce.com", "https://test.salesforce.com"},
+		{"https://test.salesforce.com/", "https://test.salesforce.com"},
+		{"  test.salesforce.com  ", "https://test.salesforce.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeURL(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestClient_BuildURL(t *testing.T) {
+	client := &Client{
+		InstanceURL: "https://test.salesforce.com",
+		APIVersion:  "v62.0",
+		BaseURL:     "https://test.salesforce.com/services/data/v62.0",
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "relative path",
+			path:     "/query",
+			expected: "https://test.salesforce.com/services/data/v62.0/query",
+		},
+		{
+			name:     "relative path without slash",
+			path:     "query",
+			expected: "https://test.salesforce.com/services/data/v62.0/query",
+		},
+		{
+			name:     "full services path",
+			path:     "/services/data/",
+			expected: "https://test.salesforce.com/services/data/",
+		},
+		{
+			name:     "absolute URL",
+			path:     "https://other.salesforce.com/path",
+			expected: "https://other.salesforce.com/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.buildURL(tt.path)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestClient_Query(t *testing.T) {
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/query")
+		assert.Contains(t, r.URL.RawQuery, "q=SELECT+Id%2C+Name+FROM+Account")
+
+		resp := QueryResult{
+			TotalSize: 2,
+			Done:      true,
+			Records: []SObject{
+				{ID: "001xx000003ABCDEF", Attributes: SObjectAttributes{Type: "Account"}},
+				{ID: "001xx000003GHIJKL", Attributes: SObjectAttributes{Type: "Account"}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	result, err := client.Query(context.Background(), "SELECT Id, Name FROM Account")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.TotalSize)
+	assert.True(t, result.Done)
+	assert.Len(t, result.Records, 2)
+}
+
+func TestClient_QueryAll(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// First page
+			resp := QueryResult{
+				TotalSize:      3,
+				Done:           false,
+				NextRecordsURL: "/services/data/v62.0/query/01gxx0000000001-2000",
+				Records: []SObject{
+					{ID: "001"},
+					{ID: "002"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		} else {
+			// Second page
+			resp := QueryResult{
+				TotalSize: 3,
+				Done:      true,
+				Records: []SObject{
+					{ID: "003"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	result, err := client.QueryAll(context.Background(), "SELECT Id FROM Account")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, callCount)
+	assert.True(t, result.Done)
+	assert.Len(t, result.Records, 3)
+}
+
+func TestClient_GetRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/services/data/v62.0/sobjects/Account/001xx000003ABCDEF", r.URL.Path)
+
+		resp := map[string]interface{}{
+			"attributes": map[string]string{"type": "Account"},
+			"Id":         "001xx000003ABCDEF",
+			"Name":       "Test Account",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	record, err := client.GetRecord(context.Background(), "Account", "001xx000003ABCDEF", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "001xx000003ABCDEF", record.ID)
+	assert.Equal(t, "Account", record.Attributes.Type)
+	assert.Equal(t, "Test Account", record.GetString("Name"))
+}
+
+func TestClient_CreateRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/services/data/v62.0/sobjects/Account/", r.URL.Path)
+
+		w.WriteHeader(http.StatusCreated)
+		resp := RecordResult{
+			ID:      "001xx000003NEWREC",
+			Success: true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	result, err := client.CreateRecord(context.Background(), "Account", map[string]interface{}{
+		"Name": "New Account",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, result.Success)
+	assert.Equal(t, "001xx000003NEWREC", result.ID)
+}
+
+func TestClient_UpdateRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/services/data/v62.0/sobjects/Account/001xx000003ABCDEF", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = client.UpdateRecord(context.Background(), "Account", "001xx000003ABCDEF", map[string]interface{}{
+		"Name": "Updated Account",
+	})
+	require.NoError(t, err)
+}
+
+func TestClient_DeleteRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/services/data/v62.0/sobjects/Account/001xx000003ABCDEF", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = client.DeleteRecord(context.Background(), "Account", "001xx000003ABCDEF")
+	require.NoError(t, err)
+}
+
+func TestClient_GetAPIVersions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/services/data/", r.URL.Path)
+
+		resp := []APIVersion{
+			{Label: "Winter '24", URL: "/services/data/v59.0", Version: "59.0"},
+			{Label: "Spring '24", URL: "/services/data/v60.0", Version: "60.0"},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	versions, err := client.GetAPIVersions(context.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, versions, 2)
+	assert.Equal(t, "59.0", versions[0].Version)
+}
+
+func TestClient_GetSObjects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/services/data/v62.0/sobjects/", r.URL.Path)
+
+		resp := SObjectsResponse{
+			Encoding:     "UTF-8",
+			MaxBatchSize: 200,
+			SObjects: []SObjectDescribe{
+				{Name: "Account", Label: "Account", Queryable: true},
+				{Name: "Contact", Label: "Contact", Queryable: true},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	resp, err := client.GetSObjects(context.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, resp.SObjects, 2)
+	assert.Equal(t, "Account", resp.SObjects[0].Name)
+}
+
+func TestClient_DescribeSObject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/services/data/v62.0/sobjects/Account/describe", r.URL.Path)
+
+		resp := SObjectDescribe{
+			Name:       "Account",
+			Label:      "Account",
+			Createable: true,
+			Updateable: true,
+			Fields: []Field{
+				{Name: "Id", Label: "Account ID", Type: "id"},
+				{Name: "Name", Label: "Account Name", Type: "string"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeSObject(context.Background(), "Account")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Account", desc.Name)
+	assert.Len(t, desc.Fields, 2)
+}
+
+func TestClient_GetLimits(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/services/data/v62.0/limits/", r.URL.Path)
+
+		resp := Limits{
+			"DailyApiRequests":     LimitInfo{Max: 15000, Remaining: 14500},
+			"DailyBulkApiRequests": LimitInfo{Max: 5000, Remaining: 4999},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	limits, err := client.GetLimits(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 15000, limits["DailyApiRequests"].Max)
+	assert.Equal(t, 14500, limits["DailyApiRequests"].Remaining)
+}
+
+func TestClient_ErrorHandling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		resp := []SalesforceError{
+			{ErrorCode: "MALFORMED_QUERY", Message: "Invalid SOQL syntax"},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		InstanceURL: server.URL,
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+
+	_, err = client.Query(context.Background(), "INVALID SOQL")
+	require.Error(t, err)
+
+	assert.True(t, IsBadRequest(err))
+	assert.Contains(t, err.Error(), "MALFORMED_QUERY")
+}
+
+func TestClient_RecordURL(t *testing.T) {
+	client := &Client{
+		InstanceURL: "https://mycompany.my.salesforce.com",
+	}
+
+	url := client.RecordURL("001xx000003ABCDEF")
+	assert.Equal(t, "https://mycompany.my.salesforce.com/001xx000003ABCDEF", url)
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Sentinel errors for common API error conditions
+var (
+	ErrNotFound       = errors.New("resource not found")
+	ErrUnauthorized   = errors.New("unauthorized - check your OAuth token")
+	ErrForbidden      = errors.New("forbidden - insufficient permissions")
+	ErrBadRequest     = errors.New("bad request")
+	ErrRateLimited    = errors.New("rate limited - try again later")
+	ErrServerError    = errors.New("server error")
+	ErrInvalidSession = errors.New("invalid session - token may be expired")
+)
+
+// Validation errors
+var (
+	ErrInstanceURLRequired = errors.New("instance URL is required")
+	ErrHTTPClientRequired  = errors.New("HTTP client is required")
+)
+
+// APIError represents a Salesforce API error response.
+// Salesforce returns errors as an array: [{"errorCode": "...", "message": "...", "fields": [...]}]
+type APIError struct {
+	StatusCode int
+	Errors     []SalesforceError
+}
+
+// SalesforceError represents a single error from the Salesforce API
+type SalesforceError struct {
+	ErrorCode string   `json:"errorCode"`
+	Message   string   `json:"message"`
+	Fields    []string `json:"fields,omitempty"`
+}
+
+// Error implements the error interface
+func (e *APIError) Error() string {
+	if len(e.Errors) == 0 {
+		return fmt.Sprintf("API error: HTTP %d", e.StatusCode)
+	}
+
+	if len(e.Errors) == 1 {
+		err := e.Errors[0]
+		if len(err.Fields) > 0 {
+			return fmt.Sprintf("%s: %s (fields: %s)", err.ErrorCode, err.Message, strings.Join(err.Fields, ", "))
+		}
+		return fmt.Sprintf("%s: %s", err.ErrorCode, err.Message)
+	}
+
+	// Multiple errors
+	var msgs []string
+	for _, err := range e.Errors {
+		if len(err.Fields) > 0 {
+			msgs = append(msgs, fmt.Sprintf("%s: %s (fields: %s)", err.ErrorCode, err.Message, strings.Join(err.Fields, ", ")))
+		} else {
+			msgs = append(msgs, fmt.Sprintf("%s: %s", err.ErrorCode, err.Message))
+		}
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// Unwrap returns the underlying sentinel error based on status code
+func (e *APIError) Unwrap() error {
+	switch e.StatusCode {
+	case http.StatusUnauthorized:
+		// Check for invalid session
+		for _, err := range e.Errors {
+			if err.ErrorCode == "INVALID_SESSION_ID" {
+				return ErrInvalidSession
+			}
+		}
+		return ErrUnauthorized
+	case http.StatusForbidden:
+		return ErrForbidden
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusBadRequest:
+		return ErrBadRequest
+	case http.StatusTooManyRequests:
+		return ErrRateLimited
+	default:
+		if e.StatusCode >= 500 {
+			return ErrServerError
+		}
+		return nil
+	}
+}
+
+// IsNotFound returns true if the error indicates a resource was not found
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound)
+}
+
+// IsUnauthorized returns true if the error indicates an authentication failure
+func IsUnauthorized(err error) bool {
+	return errors.Is(err, ErrUnauthorized) || errors.Is(err, ErrInvalidSession)
+}
+
+// IsForbidden returns true if the error indicates insufficient permissions
+func IsForbidden(err error) bool {
+	return errors.Is(err, ErrForbidden)
+}
+
+// IsBadRequest returns true if the error indicates a bad request
+func IsBadRequest(err error) bool {
+	return errors.Is(err, ErrBadRequest)
+}
+
+// IsRateLimited returns true if the error indicates rate limiting
+func IsRateLimited(err error) bool {
+	return errors.Is(err, ErrRateLimited)
+}
+
+// IsServerError returns true if the error indicates a server error
+func IsServerError(err error) bool {
+	return errors.Is(err, ErrServerError)
+}
+
+// IsInvalidSession returns true if the error indicates an expired/invalid session
+func IsInvalidSession(err error) bool {
+	return errors.Is(err, ErrInvalidSession)
+}
+
+// ParseAPIError creates an APIError from an HTTP response.
+// The response body is read and closed.
+func ParseAPIError(resp *http.Response) error {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Errors:     []SalesforceError{{Message: "failed to read error response"}},
+		}
+	}
+
+	apiErr := &APIError{
+		StatusCode: resp.StatusCode,
+	}
+
+	// Try to parse as Salesforce error array
+	var sfErrors []SalesforceError
+	if err := json.Unmarshal(body, &sfErrors); err == nil && len(sfErrors) > 0 {
+		apiErr.Errors = sfErrors
+		return apiErr
+	}
+
+	// Try to parse as single error object
+	var sfError SalesforceError
+	if err := json.Unmarshal(body, &sfError); err == nil && sfError.ErrorCode != "" {
+		apiErr.Errors = []SalesforceError{sfError}
+		return apiErr
+	}
+
+	// Fall back to raw body as message
+	if len(body) > 0 {
+		apiErr.Errors = []SalesforceError{{Message: string(body)}}
+	}
+
+	return apiErr
+}
+
+// Common Salesforce error codes for reference:
+// - INVALID_SESSION_ID: Session expired or invalid
+// - INVALID_FIELD: Field doesn't exist or is inaccessible
+// - INVALID_TYPE: SObject type doesn't exist
+// - MALFORMED_QUERY: Invalid SOQL syntax
+// - MALFORMED_ID: Invalid record ID format
+// - INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY: Insufficient permissions
+// - DUPLICATE_VALUE: Unique constraint violation
+// - REQUIRED_FIELD_MISSING: Required field not provided
+// - FIELD_CUSTOM_VALIDATION_EXCEPTION: Custom validation rule failed
+// - STRING_TOO_LONG: Field value exceeds maximum length
+// - NUMBER_OUTSIDE_VALID_RANGE: Numeric value out of range

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,236 @@
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *APIError
+		expected string
+	}{
+		{
+			name: "empty errors",
+			err: &APIError{
+				StatusCode: 400,
+				Errors:     nil,
+			},
+			expected: "API error: HTTP 400",
+		},
+		{
+			name: "single error",
+			err: &APIError{
+				StatusCode: 400,
+				Errors: []SalesforceError{
+					{ErrorCode: "MALFORMED_QUERY", Message: "Invalid SOQL"},
+				},
+			},
+			expected: "MALFORMED_QUERY: Invalid SOQL",
+		},
+		{
+			name: "single error with fields",
+			err: &APIError{
+				StatusCode: 400,
+				Errors: []SalesforceError{
+					{ErrorCode: "INVALID_FIELD", Message: "No such column 'foo'", Fields: []string{"foo"}},
+				},
+			},
+			expected: "INVALID_FIELD: No such column 'foo' (fields: foo)",
+		},
+		{
+			name: "multiple errors",
+			err: &APIError{
+				StatusCode: 400,
+				Errors: []SalesforceError{
+					{ErrorCode: "REQUIRED_FIELD_MISSING", Message: "Required field missing: Name"},
+					{ErrorCode: "INVALID_FIELD", Message: "Invalid field: BadField", Fields: []string{"BadField"}},
+				},
+			},
+			expected: "REQUIRED_FIELD_MISSING: Required field missing: Name; INVALID_FIELD: Invalid field: BadField (fields: BadField)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestAPIError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *APIError
+		wantErr error
+	}{
+		{
+			name:    "401 unauthorized",
+			err:     &APIError{StatusCode: 401},
+			wantErr: ErrUnauthorized,
+		},
+		{
+			name: "401 invalid session",
+			err: &APIError{
+				StatusCode: 401,
+				Errors:     []SalesforceError{{ErrorCode: "INVALID_SESSION_ID", Message: "Session expired"}},
+			},
+			wantErr: ErrInvalidSession,
+		},
+		{
+			name:    "403 forbidden",
+			err:     &APIError{StatusCode: 403},
+			wantErr: ErrForbidden,
+		},
+		{
+			name:    "404 not found",
+			err:     &APIError{StatusCode: 404},
+			wantErr: ErrNotFound,
+		},
+		{
+			name:    "400 bad request",
+			err:     &APIError{StatusCode: 400},
+			wantErr: ErrBadRequest,
+		},
+		{
+			name:    "429 rate limited",
+			err:     &APIError{StatusCode: 429},
+			wantErr: ErrRateLimited,
+		},
+		{
+			name:    "500 server error",
+			err:     &APIError{StatusCode: 500},
+			wantErr: ErrServerError,
+		},
+		{
+			name:    "503 server error",
+			err:     &APIError{StatusCode: 503},
+			wantErr: ErrServerError,
+		},
+		{
+			name:    "200 no error",
+			err:     &APIError{StatusCode: 200},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Unwrap()
+			assert.Equal(t, tt.wantErr, got)
+		})
+	}
+}
+
+func TestIsHelpers(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		check  func(error) bool
+		expect bool
+	}{
+		{"IsNotFound true", &APIError{StatusCode: 404}, IsNotFound, true},
+		{"IsNotFound false", &APIError{StatusCode: 400}, IsNotFound, false},
+		{"IsUnauthorized true", &APIError{StatusCode: 401}, IsUnauthorized, true},
+		{"IsUnauthorized invalid session", &APIError{StatusCode: 401, Errors: []SalesforceError{{ErrorCode: "INVALID_SESSION_ID"}}}, IsUnauthorized, true},
+		{"IsForbidden true", &APIError{StatusCode: 403}, IsForbidden, true},
+		{"IsBadRequest true", &APIError{StatusCode: 400}, IsBadRequest, true},
+		{"IsRateLimited true", &APIError{StatusCode: 429}, IsRateLimited, true},
+		{"IsServerError true", &APIError{StatusCode: 500}, IsServerError, true},
+		{"IsInvalidSession true", &APIError{StatusCode: 401, Errors: []SalesforceError{{ErrorCode: "INVALID_SESSION_ID"}}}, IsInvalidSession, true},
+		{"IsInvalidSession false", &APIError{StatusCode: 401}, IsInvalidSession, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.check(tt.err)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func TestParseAPIError(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		body          string
+		expectErrors  int
+		expectCode    string
+		expectMessage string
+	}{
+		{
+			name:          "array format",
+			statusCode:    400,
+			body:          `[{"errorCode": "MALFORMED_QUERY", "message": "Invalid SOQL"}]`,
+			expectErrors:  1,
+			expectCode:    "MALFORMED_QUERY",
+			expectMessage: "Invalid SOQL",
+		},
+		{
+			name:          "single object format",
+			statusCode:    400,
+			body:          `{"errorCode": "INVALID_FIELD", "message": "No such column"}`,
+			expectErrors:  1,
+			expectCode:    "INVALID_FIELD",
+			expectMessage: "No such column",
+		},
+		{
+			name:          "multiple errors",
+			statusCode:    400,
+			body:          `[{"errorCode": "ERR1", "message": "First"}, {"errorCode": "ERR2", "message": "Second"}]`,
+			expectErrors:  2,
+			expectCode:    "ERR1",
+			expectMessage: "First",
+		},
+		{
+			name:          "plain text fallback",
+			statusCode:    500,
+			body:          `Internal Server Error`,
+			expectErrors:  1,
+			expectCode:    "",
+			expectMessage: "Internal Server Error",
+		},
+		{
+			name:          "with fields",
+			statusCode:    400,
+			body:          `[{"errorCode": "INVALID_FIELD", "message": "Bad field", "fields": ["Name", "Email"]}]`,
+			expectErrors:  1,
+			expectCode:    "INVALID_FIELD",
+			expectMessage: "Bad field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tt.statusCode,
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+			}
+
+			err := ParseAPIError(resp)
+			apiErr, ok := err.(*APIError)
+			assert.True(t, ok)
+			assert.Equal(t, tt.statusCode, apiErr.StatusCode)
+			assert.Len(t, apiErr.Errors, tt.expectErrors)
+			if tt.expectErrors > 0 {
+				assert.Equal(t, tt.expectCode, apiErr.Errors[0].ErrorCode)
+				assert.Equal(t, tt.expectMessage, apiErr.Errors[0].Message)
+			}
+		})
+	}
+}
+
+func TestErrorsIs(t *testing.T) {
+	// Test that errors.Is works correctly with APIError
+	apiErr := &APIError{StatusCode: 404}
+
+	assert.True(t, errors.Is(apiErr, ErrNotFound))
+	assert.False(t, errors.Is(apiErr, ErrUnauthorized))
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,241 @@
+// Package api provides a Go client for the Salesforce REST API.
+package api
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// APIVersion represents a Salesforce API version
+type APIVersion struct {
+	Label   string `json:"label"`
+	URL     string `json:"url"`
+	Version string `json:"version"`
+}
+
+// SObject represents a generic Salesforce object record
+type SObject struct {
+	// Attributes contains metadata about the record
+	Attributes SObjectAttributes `json:"attributes,omitempty"`
+
+	// ID is the Salesforce record ID (18-character)
+	ID string `json:"Id,omitempty"`
+
+	// Fields contains all other fields as a map
+	// Use GetString, GetBool, etc. helpers to access typed values
+	Fields map[string]interface{} `json:"-"`
+}
+
+// SObjectAttributes contains metadata about an SObject record
+type SObjectAttributes struct {
+	Type string `json:"type"`
+	URL  string `json:"url,omitempty"`
+}
+
+// UnmarshalJSON custom unmarshaler to capture all fields
+func (s *SObject) UnmarshalJSON(data []byte) error {
+	// First unmarshal into a map to get all fields
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	s.Fields = make(map[string]interface{})
+
+	for key, value := range raw {
+		switch key {
+		case "attributes":
+			if err := json.Unmarshal(value, &s.Attributes); err != nil {
+				return err
+			}
+		case "Id":
+			if err := json.Unmarshal(value, &s.ID); err != nil {
+				return err
+			}
+		default:
+			var v interface{}
+			if err := json.Unmarshal(value, &v); err != nil {
+				return err
+			}
+			s.Fields[key] = v
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON custom marshaler to include all fields
+func (s SObject) MarshalJSON() ([]byte, error) {
+	result := make(map[string]interface{})
+
+	if s.Attributes.Type != "" {
+		result["attributes"] = s.Attributes
+	}
+	if s.ID != "" {
+		result["Id"] = s.ID
+	}
+
+	for key, value := range s.Fields {
+		result[key] = value
+	}
+
+	return json.Marshal(result)
+}
+
+// GetString returns a string field value
+func (s *SObject) GetString(field string) string {
+	if s.Fields == nil {
+		return ""
+	}
+	if v, ok := s.Fields[field].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// GetBool returns a boolean field value
+func (s *SObject) GetBool(field string) bool {
+	if s.Fields == nil {
+		return false
+	}
+	if v, ok := s.Fields[field].(bool); ok {
+		return v
+	}
+	return false
+}
+
+// GetFloat returns a numeric field value as float64
+func (s *SObject) GetFloat(field string) float64 {
+	if s.Fields == nil {
+		return 0
+	}
+	if v, ok := s.Fields[field].(float64); ok {
+		return v
+	}
+	return 0
+}
+
+// GetInt returns a numeric field value as int
+func (s *SObject) GetInt(field string) int {
+	return int(s.GetFloat(field))
+}
+
+// GetTime parses a datetime field value
+func (s *SObject) GetTime(field string) time.Time {
+	str := s.GetString(field)
+	if str == "" {
+		return time.Time{}
+	}
+	// Salesforce datetime format: 2023-01-15T10:30:00.000+0000
+	t, _ := time.Parse("2006-01-02T15:04:05.000-0700", str)
+	return t
+}
+
+// QueryResult represents the result of a SOQL query
+type QueryResult struct {
+	TotalSize      int       `json:"totalSize"`
+	Done           bool      `json:"done"`
+	NextRecordsURL string    `json:"nextRecordsUrl,omitempty"`
+	Records        []SObject `json:"records"`
+}
+
+// RecordResult represents the result of a record create/update operation
+type RecordResult struct {
+	ID      string        `json:"id,omitempty"`
+	Success bool          `json:"success"`
+	Errors  []RecordError `json:"errors,omitempty"`
+	Created bool          `json:"created,omitempty"`
+}
+
+// RecordError represents an error from a record operation
+type RecordError struct {
+	StatusCode string   `json:"statusCode"`
+	Message    string   `json:"message"`
+	Fields     []string `json:"fields,omitempty"`
+}
+
+// CompositeRequest represents a composite API request
+type CompositeRequest struct {
+	AllOrNone          bool                  `json:"allOrNone"`
+	CollateSubrequests bool                  `json:"collateSubrequests,omitempty"`
+	CompositeRequest   []CompositeSubrequest `json:"compositeRequest"`
+}
+
+// CompositeSubrequest represents a single request within a composite batch
+type CompositeSubrequest struct {
+	Method      string                 `json:"method"`
+	URL         string                 `json:"url"`
+	ReferenceID string                 `json:"referenceId"`
+	Body        map[string]interface{} `json:"body,omitempty"`
+}
+
+// CompositeResponse represents a composite API response
+type CompositeResponse struct {
+	CompositeResponse []CompositeSubresponse `json:"compositeResponse"`
+}
+
+// CompositeSubresponse represents a single response within a composite batch
+type CompositeSubresponse struct {
+	Body           json.RawMessage   `json:"body"`
+	HTTPHeaders    map[string]string `json:"httpHeaders"`
+	HTTPStatusCode int               `json:"httpStatusCode"`
+	ReferenceID    string            `json:"referenceId"`
+}
+
+// SObjectDescribe represents metadata about an SObject type
+type SObjectDescribe struct {
+	Name        string  `json:"name"`
+	Label       string  `json:"label"`
+	LabelPlural string  `json:"labelPlural"`
+	KeyPrefix   string  `json:"keyPrefix,omitempty"`
+	Custom      bool    `json:"custom"`
+	Createable  bool    `json:"createable"`
+	Updateable  bool    `json:"updateable"`
+	Deletable   bool    `json:"deletable"`
+	Queryable   bool    `json:"queryable"`
+	Searchable  bool    `json:"searchable"`
+	Fields      []Field `json:"fields,omitempty"`
+}
+
+// Field represents a field on an SObject
+type Field struct {
+	Name              string          `json:"name"`
+	Label             string          `json:"label"`
+	Type              string          `json:"type"`
+	Length            int             `json:"length,omitempty"`
+	Precision         int             `json:"precision,omitempty"`
+	Scale             int             `json:"scale,omitempty"`
+	Nillable          bool            `json:"nillable"`
+	Createable        bool            `json:"createable"`
+	Updateable        bool            `json:"updateable"`
+	Custom            bool            `json:"custom"`
+	CalculatedFormula string          `json:"calculatedFormula,omitempty"`
+	DefaultValue      interface{}     `json:"defaultValue,omitempty"`
+	PicklistValues    []PicklistValue `json:"picklistValues,omitempty"`
+	ReferenceTo       []string        `json:"referenceTo,omitempty"`
+	RelationshipName  string          `json:"relationshipName,omitempty"`
+}
+
+// PicklistValue represents a picklist option
+type PicklistValue struct {
+	Value        string `json:"value"`
+	Label        string `json:"label"`
+	Active       bool   `json:"active"`
+	DefaultValue bool   `json:"defaultValue"`
+}
+
+// SObjectsResponse represents the response from /sobjects/
+type SObjectsResponse struct {
+	Encoding     string            `json:"encoding"`
+	MaxBatchSize int               `json:"maxBatchSize"`
+	SObjects     []SObjectDescribe `json:"sobjects"`
+}
+
+// Limits represents Salesforce org limits
+type Limits map[string]LimitInfo
+
+// LimitInfo represents a single limit value
+type LimitInfo struct {
+	Max       int `json:"Max"`
+	Remaining int `json:"Remaining"`
+}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,314 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSObject_UnmarshalJSON(t *testing.T) {
+	jsonData := `{
+		"attributes": {"type": "Account", "url": "/services/data/v62.0/sobjects/Account/001xx"},
+		"Id": "001xx000003ABCDEF",
+		"Name": "Test Account",
+		"AnnualRevenue": 1000000.50,
+		"Active__c": true,
+		"NumberOfEmployees": 100
+	}`
+
+	var obj SObject
+	err := json.Unmarshal([]byte(jsonData), &obj)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Account", obj.Attributes.Type)
+	assert.Equal(t, "/services/data/v62.0/sobjects/Account/001xx", obj.Attributes.URL)
+	assert.Equal(t, "001xx000003ABCDEF", obj.ID)
+	assert.Equal(t, "Test Account", obj.Fields["Name"])
+	assert.Equal(t, 1000000.50, obj.Fields["AnnualRevenue"])
+	assert.Equal(t, true, obj.Fields["Active__c"])
+	assert.Equal(t, float64(100), obj.Fields["NumberOfEmployees"])
+}
+
+func TestSObject_MarshalJSON(t *testing.T) {
+	obj := SObject{
+		Attributes: SObjectAttributes{Type: "Account"},
+		ID:         "001xx000003ABCDEF",
+		Fields: map[string]interface{}{
+			"Name":          "Test Account",
+			"AnnualRevenue": 1000000.50,
+		},
+	}
+
+	data, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, "001xx000003ABCDEF", result["Id"])
+	assert.Equal(t, "Test Account", result["Name"])
+	assert.Equal(t, 1000000.50, result["AnnualRevenue"])
+}
+
+func TestSObject_GetString(t *testing.T) {
+	obj := SObject{
+		Fields: map[string]interface{}{
+			"Name":   "Test Account",
+			"Number": 123,
+		},
+	}
+
+	assert.Equal(t, "Test Account", obj.GetString("Name"))
+	assert.Equal(t, "", obj.GetString("Number"))    // wrong type
+	assert.Equal(t, "", obj.GetString("NotExists")) // doesn't exist
+}
+
+func TestSObject_GetBool(t *testing.T) {
+	obj := SObject{
+		Fields: map[string]interface{}{
+			"Active":   true,
+			"Inactive": false,
+			"Name":     "Test",
+		},
+	}
+
+	assert.True(t, obj.GetBool("Active"))
+	assert.False(t, obj.GetBool("Inactive"))
+	assert.False(t, obj.GetBool("Name"))      // wrong type
+	assert.False(t, obj.GetBool("NotExists")) // doesn't exist
+}
+
+func TestSObject_GetFloat(t *testing.T) {
+	obj := SObject{
+		Fields: map[string]interface{}{
+			"Revenue": 1000000.50,
+			"Count":   float64(100),
+			"Name":    "Test",
+		},
+	}
+
+	assert.Equal(t, 1000000.50, obj.GetFloat("Revenue"))
+	assert.Equal(t, float64(100), obj.GetFloat("Count"))
+	assert.Equal(t, float64(0), obj.GetFloat("Name"))      // wrong type
+	assert.Equal(t, float64(0), obj.GetFloat("NotExists")) // doesn't exist
+}
+
+func TestSObject_GetInt(t *testing.T) {
+	obj := SObject{
+		Fields: map[string]interface{}{
+			"Count":   float64(100),
+			"Revenue": 1000000.75,
+		},
+	}
+
+	assert.Equal(t, 100, obj.GetInt("Count"))
+	assert.Equal(t, 1000000, obj.GetInt("Revenue")) // truncates decimal
+}
+
+func TestSObject_GetTime(t *testing.T) {
+	obj := SObject{
+		Fields: map[string]interface{}{
+			"CreatedDate": "2024-01-15T10:30:00.000+0000",
+			"Name":        "Test",
+		},
+	}
+
+	expected := time.Date(2024, 1, 15, 10, 30, 0, 0, time.FixedZone("", 0))
+	assert.Equal(t, expected, obj.GetTime("CreatedDate"))
+	assert.True(t, obj.GetTime("Name").IsZero())      // wrong type
+	assert.True(t, obj.GetTime("NotExists").IsZero()) // doesn't exist
+}
+
+func TestSObject_NilFields(t *testing.T) {
+	obj := SObject{}
+
+	// Should not panic with nil Fields map
+	assert.Equal(t, "", obj.GetString("Name"))
+	assert.False(t, obj.GetBool("Active"))
+	assert.Equal(t, float64(0), obj.GetFloat("Revenue"))
+	assert.Equal(t, 0, obj.GetInt("Count"))
+}
+
+func TestQueryResult_Unmarshal(t *testing.T) {
+	jsonData := `{
+		"totalSize": 2,
+		"done": true,
+		"records": [
+			{"attributes": {"type": "Account"}, "Id": "001", "Name": "Account 1"},
+			{"attributes": {"type": "Account"}, "Id": "002", "Name": "Account 2"}
+		]
+	}`
+
+	var result QueryResult
+	err := json.Unmarshal([]byte(jsonData), &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.TotalSize)
+	assert.True(t, result.Done)
+	assert.Len(t, result.Records, 2)
+	assert.Equal(t, "001", result.Records[0].ID)
+	assert.Equal(t, "Account 1", result.Records[0].GetString("Name"))
+}
+
+func TestQueryResult_WithNextRecords(t *testing.T) {
+	jsonData := `{
+		"totalSize": 5000,
+		"done": false,
+		"nextRecordsUrl": "/services/data/v62.0/query/01gxx0000000001-2000",
+		"records": []
+	}`
+
+	var result QueryResult
+	err := json.Unmarshal([]byte(jsonData), &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5000, result.TotalSize)
+	assert.False(t, result.Done)
+	assert.Equal(t, "/services/data/v62.0/query/01gxx0000000001-2000", result.NextRecordsURL)
+}
+
+func TestRecordResult_Success(t *testing.T) {
+	jsonData := `{
+		"id": "001xx000003ABCDEF",
+		"success": true,
+		"errors": []
+	}`
+
+	var result RecordResult
+	err := json.Unmarshal([]byte(jsonData), &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, "001xx000003ABCDEF", result.ID)
+	assert.True(t, result.Success)
+	assert.Empty(t, result.Errors)
+}
+
+func TestRecordResult_WithErrors(t *testing.T) {
+	jsonData := `{
+		"success": false,
+		"errors": [
+			{"statusCode": "REQUIRED_FIELD_MISSING", "message": "Required fields are missing: [Name]", "fields": ["Name"]}
+		]
+	}`
+
+	var result RecordResult
+	err := json.Unmarshal([]byte(jsonData), &result)
+	require.NoError(t, err)
+
+	assert.False(t, result.Success)
+	assert.Len(t, result.Errors, 1)
+	assert.Equal(t, "REQUIRED_FIELD_MISSING", result.Errors[0].StatusCode)
+	assert.Contains(t, result.Errors[0].Fields, "Name")
+}
+
+func TestSObjectDescribe(t *testing.T) {
+	jsonData := `{
+		"name": "Account",
+		"label": "Account",
+		"labelPlural": "Accounts",
+		"keyPrefix": "001",
+		"custom": false,
+		"createable": true,
+		"updateable": true,
+		"deletable": true,
+		"queryable": true,
+		"searchable": true,
+		"fields": [
+			{
+				"name": "Id",
+				"label": "Account ID",
+				"type": "id",
+				"nillable": false,
+				"createable": false,
+				"updateable": false
+			},
+			{
+				"name": "Name",
+				"label": "Account Name",
+				"type": "string",
+				"length": 255,
+				"nillable": false,
+				"createable": true,
+				"updateable": true
+			}
+		]
+	}`
+
+	var desc SObjectDescribe
+	err := json.Unmarshal([]byte(jsonData), &desc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Account", desc.Name)
+	assert.Equal(t, "Accounts", desc.LabelPlural)
+	assert.Equal(t, "001", desc.KeyPrefix)
+	assert.True(t, desc.Createable)
+	assert.True(t, desc.Queryable)
+	assert.Len(t, desc.Fields, 2)
+	assert.Equal(t, "id", desc.Fields[0].Type)
+	assert.Equal(t, 255, desc.Fields[1].Length)
+}
+
+func TestAPIVersion(t *testing.T) {
+	jsonData := `{
+		"label": "Spring '24",
+		"url": "/services/data/v60.0",
+		"version": "60.0"
+	}`
+
+	var version APIVersion
+	err := json.Unmarshal([]byte(jsonData), &version)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Spring '24", version.Label)
+	assert.Equal(t, "/services/data/v60.0", version.URL)
+	assert.Equal(t, "60.0", version.Version)
+}
+
+func TestLimits(t *testing.T) {
+	jsonData := `{
+		"DailyApiRequests": {"Max": 15000, "Remaining": 14500},
+		"DailyBulkApiRequests": {"Max": 5000, "Remaining": 4999}
+	}`
+
+	var limits Limits
+	err := json.Unmarshal([]byte(jsonData), &limits)
+	require.NoError(t, err)
+
+	assert.Equal(t, 15000, limits["DailyApiRequests"].Max)
+	assert.Equal(t, 14500, limits["DailyApiRequests"].Remaining)
+	assert.Equal(t, 5000, limits["DailyBulkApiRequests"].Max)
+}
+
+func TestCompositeRequest(t *testing.T) {
+	req := CompositeRequest{
+		AllOrNone: true,
+		CompositeRequest: []CompositeSubrequest{
+			{
+				Method:      "POST",
+				URL:         "/services/data/v62.0/sobjects/Account",
+				ReferenceID: "newAccount",
+				Body:        map[string]interface{}{"Name": "New Account"},
+			},
+			{
+				Method:      "GET",
+				URL:         "/services/data/v62.0/sobjects/Account/@{newAccount.id}",
+				ReferenceID: "getAccount",
+			},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var result CompositeRequest
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	assert.True(t, result.AllOrNone)
+	assert.Len(t, result.CompositeRequest, 2)
+	assert.Equal(t, "newAccount", result.CompositeRequest[0].ReferenceID)
+}


### PR DESCRIPTION
## Summary

- Implement the public `api/` package for Salesforce REST API access
- Comprehensive client with OAuth support, error handling, and all CRUD operations
- Well-typed data structures for Salesforce objects and responses

### API Client (`api/client.go`)

- HTTP methods: `Get()`, `Post()`, `Patch()`, `Put()`, `Delete()`
- Query operations: `Query()`, `QueryMore()`, `QueryAll()` (with automatic pagination)
- Record CRUD: `GetRecord()`, `CreateRecord()`, `UpdateRecord()`, `DeleteRecord()`
- API discovery: `GetAPIVersions()`, `GetSObjects()`, `DescribeSObject()`, `GetLimits()`
- Default API version: v62.0

### Error Handling (`api/errors.go`)

- Parse Salesforce error format: `[{"errorCode": "...", "message": "...", "fields": [...]}]`
- Sentinel errors with `errors.Is()` support
- Classification helpers: `IsNotFound()`, `IsUnauthorized()`, `IsRateLimited()`, etc.
- Special handling for `INVALID_SESSION_ID` (expired tokens)

### Data Types (`api/types.go`)

- `SObject`: Generic record with dynamic field access (`GetString()`, `GetBool()`, `GetTime()`, etc.)
- `QueryResult`: SOQL results with pagination support
- `RecordResult`: Create/update operation results
- `CompositeRequest/Response`: Batch operation support
- `SObjectDescribe`, `Field`, `APIVersion`, `Limits`

## Test plan

- [x] `make test` passes with race detection
- [x] `make lint` passes
- [x] Comprehensive unit tests with `httptest` server mocking
- [x] Table-driven tests for error parsing
- [x] Tests for all client methods (Query, CRUD, API discovery)
- [x] Tests for SObject field accessors and JSON marshaling

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)