### PR TITLE
feat: implement CLI framework and root command

### DIFF
--- a/cmd/sfdc/main.go
+++ b/cmd/sfdc/main.go
@@ -5,18 +5,33 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/open-cli-collective/salesforce-cli/internal/version"
+	"github.com/open-cli-collective/salesforce-cli/internal/cmd/completion"
+	"github.com/open-cli-collective/salesforce-cli/internal/cmd/configcmd"
+	"github.com/open-cli-collective/salesforce-cli/internal/cmd/initcmd"
+	"github.com/open-cli-collective/salesforce-cli/internal/cmd/root"
+)
+
+// Exit codes
+const (
+	exitOK    = 0
+	exitError = 1
 )
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(exitError)
 	}
+	os.Exit(exitOK)
 }
 
 func run() error {
-	// TODO: Initialize root command and execute
-	fmt.Printf("sfdc %s\n", version.Info())
-	return nil
+	rootCmd, opts := root.NewCmd()
+
+	// Register all commands
+	initcmd.Register(rootCmd, opts)
+	configcmd.Register(rootCmd, opts)
+	completion.Register(rootCmd, opts)
+
+	return rootCmd.Execute()
 }

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -1,0 +1,67 @@
+// Package completion provides shell completion support.
+package completion
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/salesforce-cli/internal/cmd/root"
+)
+
+// Register registers the completion command
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for sfdc.
+
+To load completions:
+
+Bash:
+  $ source <(sfdc completion bash)
+  # To load completions for each session, execute once:
+  # Linux:
+  $ sfdc completion bash > /etc/bash_completion.d/sfdc
+  # macOS:
+  $ sfdc completion bash > $(brew --prefix)/etc/bash_completion.d/sfdc
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+  # To load completions for each session, execute once:
+  $ sfdc completion zsh > "${fpath[1]}/_sfdc"
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ sfdc completion fish | source
+  # To load completions for each session, execute once:
+  $ sfdc completion fish > ~/.config/fish/completions/sfdc.fish
+
+PowerShell:
+  PS> sfdc completion powershell | Out-String | Invoke-Expression
+  # To load completions for every new session, run:
+  PS> sfdc completion powershell > sfdc.ps1
+  # and source this file from your PowerShell profile.
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				return cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+			return nil
+		},
+	}
+
+	parent.AddCommand(cmd)
+}

--- a/internal/cmd/completion/completion_test.go
+++ b/internal/cmd/completion/completion_test.go
@@ -1,0 +1,87 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-cli-collective/salesforce-cli/internal/cmd/root"
+)
+
+func TestRegister(t *testing.T) {
+	rootCmd, opts := root.NewCmd()
+	Register(rootCmd, opts)
+
+	// Check that completion command was added
+	completionCmd, _, err := rootCmd.Find([]string{"completion"})
+	assert.NoError(t, err)
+	assert.NotNil(t, completionCmd)
+	assert.Equal(t, "completion [bash|zsh|fish|powershell]", completionCmd.Use)
+
+	// Check valid args
+	assert.Contains(t, completionCmd.ValidArgs, "bash")
+	assert.Contains(t, completionCmd.ValidArgs, "zsh")
+	assert.Contains(t, completionCmd.ValidArgs, "fish")
+	assert.Contains(t, completionCmd.ValidArgs, "powershell")
+}
+
+func TestCompletion_RequiresArg(t *testing.T) {
+	rootCmd, opts := root.NewCmd()
+	Register(rootCmd, opts)
+
+	// Running without args should fail
+	rootCmd.SetArgs([]string{"completion"})
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestCompletion_InvalidArg(t *testing.T) {
+	rootCmd, opts := root.NewCmd()
+	Register(rootCmd, opts)
+
+	// Running with invalid arg should fail
+	rootCmd.SetArgs([]string{"completion", "invalid"})
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestCompletion_Bash(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "sfdc"}
+	opts := &root.Options{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"completion", "bash"})
+	err := rootCmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestCompletion_Zsh(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "sfdc"}
+	opts := &root.Options{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"completion", "zsh"})
+	err := rootCmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestCompletion_Fish(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "sfdc"}
+	opts := &root.Options{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"completion", "fish"})
+	err := rootCmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestCompletion_PowerShell(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "sfdc"}
+	opts := &root.Options{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"completion", "powershell"})
+	err := rootCmd.Execute()
+	assert.NoError(t, err)
+}

--- a/internal/cmd/configcmd/configcmd.go
+++ b/internal/cmd/configcmd/configcmd.go
@@ -14,6 +14,12 @@ import (
 	"github.com/open-cli-collective/salesforce-cli/internal/keychain"
 )
 
+// Register registers the config command with the parent command.
+// The opts parameter is accepted for consistency with other commands but not used.
+func Register(parent *cobra.Command, _ interface{}) {
+	parent.AddCommand(NewCommand())
+}
+
 // NewCommand returns the config command with subcommands.
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -27,6 +27,12 @@ var (
 	noBrowser   bool
 )
 
+// Register registers the init command with the parent command.
+// The opts parameter is accepted for consistency with other commands but not used.
+func Register(parent *cobra.Command, _ interface{}) {
+	parent.AddCommand(NewCommand())
+}
+
 // NewCommand returns the init command.
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -1,0 +1,102 @@
+// Package root provides the root command and global options.
+package root
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/salesforce-cli/api"
+	"github.com/open-cli-collective/salesforce-cli/internal/auth"
+	"github.com/open-cli-collective/salesforce-cli/internal/config"
+	"github.com/open-cli-collective/salesforce-cli/internal/version"
+	"github.com/open-cli-collective/salesforce-cli/internal/view"
+)
+
+// Options contains global options for commands
+type Options struct {
+	Output     string
+	NoColor    bool
+	Verbose    bool
+	APIVersion string
+	Stdin      io.Reader
+	Stdout     io.Writer
+	Stderr     io.Writer
+
+	// testClient is used for testing; if set, APIClient() returns this instead
+	testClient *api.Client
+}
+
+// View returns a configured View instance
+func (o *Options) View() *view.View {
+	v := view.NewWithFormat(o.Output, o.NoColor)
+	v.Out = o.Stdout
+	v.Err = o.Stderr
+	return v
+}
+
+// APIClient creates a new API client from config
+func (o *Options) APIClient() (*api.Client, error) {
+	if o.testClient != nil {
+		return o.testClient, nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient, err := auth.GetHTTPClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return api.New(api.ClientConfig{
+		InstanceURL: cfg.InstanceURL,
+		HTTPClient:  httpClient,
+		APIVersion:  o.APIVersion,
+	})
+}
+
+// SetAPIClient sets a test client (for testing only)
+func (o *Options) SetAPIClient(client *api.Client) {
+	o.testClient = client
+}
+
+// NewCmd creates the root command and returns the options struct
+func NewCmd() (*cobra.Command, *Options) {
+	opts := &Options{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "sfdc",
+		Short: "A CLI for Salesforce",
+		Long: `sfdc is a command-line interface for Salesforce.
+
+It provides tools for querying data, managing records, and more.
+Run 'sfdc init' to set up authentication.`,
+		Version:       version.Info(),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	// Global flags - bound to opts struct
+	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, plain")
+	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "Disable colored output")
+	cmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable verbose output")
+	cmd.PersistentFlags().StringVar(&opts.APIVersion, "api-version", "", "Salesforce API version (default: v62.0)")
+
+	return cmd, opts
+}
+
+// RegisterCommands registers subcommands with the root command
+func RegisterCommands(root *cobra.Command, opts *Options, registrars ...func(*cobra.Command, *Options)) {
+	for _, register := range registrars {
+		register(root, opts)
+	}
+}

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -1,0 +1,83 @@
+package root
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd, opts := NewCmd()
+
+	assert.Equal(t, "sfdc", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.NotEmpty(t, cmd.Version)
+
+	// Check global flags exist
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("output"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("no-color"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("verbose"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("api-version"))
+
+	// Check default values
+	assert.Equal(t, "table", opts.Output)
+	assert.False(t, opts.NoColor)
+	assert.False(t, opts.Verbose)
+}
+
+func TestOptions_View(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	opts := &Options{
+		Output:  "json",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  stderr,
+	}
+
+	v := opts.View()
+	require.NotNil(t, v)
+
+	// View should use the configured output format
+	assert.Equal(t, "json", opts.Output)
+}
+
+func TestOptions_SetAPIClient(t *testing.T) {
+	opts := &Options{}
+
+	// Without test client, APIClient() would try to load config
+	// With test client set, it returns the test client
+	opts.SetAPIClient(nil)
+	assert.Nil(t, opts.testClient)
+}
+
+func TestRegisterCommands(t *testing.T) {
+	cmd, opts := NewCmd()
+
+	called := false
+	registrar := func(parent *cobra.Command, o *Options) {
+		called = true
+		assert.Same(t, cmd, parent)
+		assert.Same(t, opts, o)
+	}
+
+	RegisterCommands(cmd, opts, registrar)
+	assert.True(t, called)
+}
+
+func TestRegisterCommands_Multiple(t *testing.T) {
+	cmd, opts := NewCmd()
+
+	callCount := 0
+	registrar1 := func(parent *cobra.Command, o *Options) { callCount++ }
+	registrar2 := func(parent *cobra.Command, o *Options) { callCount++ }
+	registrar3 := func(parent *cobra.Command, o *Options) { callCount++ }
+
+	RegisterCommands(cmd, opts, registrar1, registrar2, registrar3)
+	assert.Equal(t, 3, callCount)
+}


### PR DESCRIPTION
## Summary

- Implement the CLI framework with Cobra
- Create root command with Options struct and global flags
- Add shell completion support (bash, zsh, fish, powershell)
- Wire up all existing commands using Register pattern

### Root Command (`internal/cmd/root/`)

- `Options` struct: `Output`, `NoColor`, `Verbose`, `APIVersion`, `Stdin`, `Stdout`, `Stderr`
- `View()` method: Returns configured view.View for output formatting
- `APIClient()` method: Returns authenticated api.Client
- Global flags: `--output/-o`, `--no-color`, `--verbose/-v`, `--api-version`
- `RegisterCommands()`: Generic command registration pattern

### Entry Point (`cmd/sfdc/main.go`)

- Creates root command and options
- Registers all subcommands: init, config, completion
- Error handling with appropriate exit codes

### Shell Completion (`internal/cmd/completion/`)

- Supports bash, zsh, fish, powershell
- Follows standard Cobra completion patterns
- Comprehensive usage examples in help text

### Command Structure

```
sfdc
├── init        # OAuth setup wizard
├── config      # Configuration management
│   ├── show
│   ├── test
│   └── clear
└── completion  # Shell completion
    ├── bash
    ├── zsh
    ├── fish
    └── powershell
```

## Test plan

- [x] `make build` produces working binary
- [x] `make test` passes with race detection
- [x] `make lint` passes
- [x] `sfdc --help` shows all commands and global flags
- [x] `sfdc --version` shows correct version
- [x] `sfdc completion bash` generates valid completion script
- [x] `sfdc init --help` shows init command help
- [x] `sfdc config --help` shows config subcommands

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)