### PR TITLE
ci: align workflows with google-readonly patterns

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,16 +3,24 @@ name: Auto Release
 on:
   push:
     branches: [main]
+    # Gate 1: Only trigger when Go code actually changes
     paths:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     runs-on: ubuntu-latest
-    # Dual-gate: Only create release for feat: or fix: commits
-    if: startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:')
+    # Gate 2: Only release for feat: and fix: commits (actual functionality changes)
+    if: >-
+      startsWith(github.event.head_commit.message, 'feat:') ||
+      startsWith(github.event.head_commit.message, 'feat(') ||
+      startsWith(github.event.head_commit.message, 'fix:') ||
+      startsWith(github.event.head_commit.message, 'fix(')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,10 +1,10 @@
-name: Chocolatey Publish
+name: Publish to Chocolatey
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 0.1.123)'
+        description: 'Version to publish (e.g., 0.1.0)'
         required: true
         type: string
 
@@ -14,39 +14,62 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download release assets
+      - name: Validate release exists
+        shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --repo ${{ github.repository }} --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
         run: |
           $version = "${{ inputs.version }}"
-          $tag = "v$version"
-          gh release download $tag --pattern "sfdc_${version}_windows_*.zip" --pattern "checksums.txt" --dir artifacts
 
-      - name: Extract checksums
-        run: |
-          $version = "${{ inputs.version }}"
-          $checksums = Get-Content artifacts/checksums.txt
-          $amd64 = ($checksums | Select-String "sfdc_${version}_windows_amd64.zip").ToString().Split(" ")[0]
-          $arm64 = ($checksums | Select-String "sfdc_${version}_windows_arm64.zip").ToString().Split(" ")[0]
-          echo "CHECKSUM_AMD64=$amd64" >> $env:GITHUB_ENV
-          echo "CHECKSUM_ARM64=$arm64" >> $env:GITHUB_ENV
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/salesforce-cli.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
 
-      - name: Update nuspec version
-        run: |
-          $version = "${{ inputs.version }}"
-          $nuspec = Get-Content packaging/chocolatey/salesforce-cli.nuspec
-          $nuspec = $nuspec -replace '<version>.*</version>', "<version>$version</version>"
-          $nuspec | Set-Content packaging/chocolatey/salesforce-cli.nuspec
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
 
-      - name: Update install script checksums
-        run: |
-          $script = Get-Content packaging/chocolatey/tools/chocolateyInstall.ps1
-          $script = $script -replace "CHECKSUM_AMD64_PLACEHOLDER", $env:CHECKSUM_AMD64
-          $script = $script -replace "CHECKSUM_ARM64_PLACEHOLDER", $env:CHECKSUM_ARM64
-          $script | Set-Content packaging/chocolatey/tools/chocolateyInstall.ps1
-
-      - name: Pack and push
+      - name: Pack Chocolatey package
+        shell: pwsh
         run: |
           cd packaging/chocolatey
           choco pack
-          choco push salesforce-cli.${{ inputs.version }}.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.CHOCOLATEY_API_KEY }}
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v0.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,18 +17,13 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ env.TAG }}
           fetch-depth: 0
-
-      - name: Get version from tag
-        id: get_version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v5
         with:
@@ -41,71 +42,158 @@ jobs:
   chocolatey:
     needs: goreleaser
     runs-on: windows-latest
+    continue-on-error: true
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download release assets
+      - name: Get checksums from release
+        shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          $version = "${{ needs.goreleaser.outputs.version }}"
-          $tag = "v$version"
-          gh release download $tag --pattern "sfdc_${version}_windows_*.zip" --pattern "checksums.txt" --dir artifacts
+          gh release download "${{ env.TAG }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
 
-      - name: Extract checksums
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
         run: |
-          $version = "${{ needs.goreleaser.outputs.version }}"
-          $checksums = Get-Content artifacts/checksums.txt
-          $amd64 = ($checksums | Select-String "sfdc_${version}_windows_amd64.zip").ToString().Split(" ")[0]
-          $arm64 = ($checksums | Select-String "sfdc_${version}_windows_arm64.zip").ToString().Split(" ")[0]
-          echo "CHECKSUM_AMD64=$amd64" >> $env:GITHUB_ENV
-          echo "CHECKSUM_ARM64=$arm64" >> $env:GITHUB_ENV
+          $version = "${{ env.TAG }}".TrimStart('v')
 
-      - name: Update nuspec version
-        run: |
-          $version = "${{ needs.goreleaser.outputs.version }}"
-          $nuspec = Get-Content packaging/chocolatey/salesforce-cli.nuspec
-          $nuspec = $nuspec -replace '<version>.*</version>', "<version>$version</version>"
-          $nuspec | Set-Content packaging/chocolatey/salesforce-cli.nuspec
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/salesforce-cli.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
 
-      - name: Update install script checksums
-        run: |
-          $script = Get-Content packaging/chocolatey/tools/chocolateyInstall.ps1
-          $script = $script -replace "CHECKSUM_AMD64_PLACEHOLDER", $env:CHECKSUM_AMD64
-          $script = $script -replace "CHECKSUM_ARM64_PLACEHOLDER", $env:CHECKSUM_ARM64
-          $script | Set-Content packaging/chocolatey/tools/chocolateyInstall.ps1
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
 
-      - name: Pack and push
+      - name: Pack Chocolatey package
+        shell: pwsh
         run: |
           cd packaging/chocolatey
           choco pack
-          choco push salesforce-cli.${{ needs.goreleaser.outputs.version }}.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.CHOCOLATEY_API_KEY }}
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}
 
   winget:
     needs: goreleaser
     runs-on: windows-latest
+    continue-on-error: true
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download checksums
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          $version = "${{ needs.goreleaser.outputs.version }}"
-          $tag = "v$version"
-          gh release download $tag --pattern "checksums.txt" --dir artifacts
-
       - name: Install wingetcreate
+        shell: pwsh
         run: |
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      - name: Update and submit manifest
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
         run: |
-          $version = "${{ needs.goreleaser.outputs.version }}"
-          $baseUrl = "https://github.com/open-cli-collective/salesforce-cli/releases/download/v$version"
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/salesforce-cli" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate submit"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
 
-          ./wingetcreate.exe update OpenCLICollective.salesforce-cli `
-            --version $version `
-            --urls "$baseUrl/sfdc_${version}_windows_amd64.zip|x64" "$baseUrl/sfdc_${version}_windows_arm64.zip|arm64" `
-            --submit `
-            --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ env.TAG }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ env.TAG }}".TrimStart('v')
+          $x64 = "https://github.com/open-cli-collective/salesforce-cli/releases/download/${{ env.TAG }}/sfdc_${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/salesforce-cli/releases/download/${{ env.TAG }}/sfdc_${version}_windows_arm64.zip"
+
+          Write-Host "Updating existing manifest to version $version"
+          Write-Host "x64 URL: $x64"
+          Write-Host "arm64 URL: $arm64"
+          ./wingetcreate.exe update OpenCLICollective.salesforce-cli --version $version --urls $x64 $arm64 --submit --token $env:WINGET_GITHUB_TOKEN
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ env.TAG }}".TrimStart('v')
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.salesforce-cli.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.salesforce-cli.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          # Use .NET regex for sequential replacement (PowerShell -replace doesn't support count)
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
+          Set-Content "$manifestDir/OpenCLICollective.salesforce-cli.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token $env:WINGET_GITHUB_TOKEN $manifestDir

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -1,0 +1,83 @@
+name: Test Chocolatey Package
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/chocolatey/**'
+      - '.github/workflows/test-chocolatey.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/chocolatey/**'
+      - '.github/workflows/test-chocolatey.yml'
+
+jobs:
+  test-chocolatey:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build binary for testing
+        run: go build -o packaging/chocolatey/tools/sfdc.exe ./cmd/sfdc
+
+      - name: Prepare test package
+        shell: pwsh
+        working-directory: packaging/chocolatey
+        run: |
+          # Replace placeholder version with test version (must not be prerelease)
+          (Get-Content salesforce-cli.nuspec) `
+            -replace '<version>0.0.0</version>', '<version>0.0.1</version>' |
+            Set-Content salesforce-cli.nuspec
+
+          # Create a simple install script that uses the local binary
+          # (the real script downloads from GitHub, but we test structure here)
+          @'
+          $ErrorActionPreference = 'Stop'
+          $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+          # Binary is already in tools/ from CI build
+          Write-Host "salesforce-cli installed from local build for testing"
+
+          # Exclude non-executables from shimming
+          New-Item "$toolsDir\LICENSE.ignore" -Type File -Force | Out-Null
+          New-Item "$toolsDir\README.md.ignore" -Type File -Force | Out-Null
+          '@ | Set-Content tools/chocolateyInstall.ps1
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        working-directory: packaging/chocolatey
+        run: choco pack
+
+      - name: Install package locally
+        shell: pwsh
+        working-directory: packaging/chocolatey
+        run: choco install salesforce-cli -dv -s . --force
+
+      - name: Verify installation
+        shell: pwsh
+        run: |
+          Write-Host "Testing sfdc --version..."
+          sfdc --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "sfdc --version failed"
+            exit 1
+          }
+          Write-Host "sfdc is working!"
+
+      - name: Test uninstall
+        shell: pwsh
+        run: |
+          choco uninstall salesforce-cli -y
+
+          # Verify sfdc is no longer available
+          $sfdcPath = Get-Command sfdc -ErrorAction SilentlyContinue
+          if ($sfdcPath) {
+            Write-Error "sfdc should not be available after uninstall"
+            exit 1
+          }
+          Write-Host "Uninstall successful!"

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -1,0 +1,60 @@
+name: Test Winget Manifest
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+
+jobs:
+  validate-winget:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate manifest schema
+        shell: pwsh
+        run: |
+          $testDir = "winget-validate-test"
+          $testVersion = "0.0.1"
+          $testHash1 = "0000000000000000000000000000000000000000000000000000000000000001"
+          $testHash2 = "0000000000000000000000000000000000000000000000000000000000000002"
+
+          New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+
+          # Read actual templates and substitute placeholders for validation
+          Write-Host "Reading and processing actual template files..."
+
+          # Version manifest
+          $content = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.salesforce-cli.yaml" $content -Encoding UTF8
+
+          # Locale manifest
+          $content = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.locale.en-US.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.salesforce-cli.locale.en-US.yaml" $content -Encoding UTF8
+
+          # Installer manifest (substitute version and checksums)
+          $content = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.installer.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          $regex = [regex]"0{64}"
+          $content = $regex.Replace($content, $testHash1, 1)
+          $content = $regex.Replace($content, $testHash2, 1)
+          Set-Content "$testDir/OpenCLICollective.salesforce-cli.installer.yaml" $content -Encoding UTF8
+
+          Write-Host "Generated test manifests:"
+          Get-ChildItem $testDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating winget manifest schema..."
+          winget validate --manifest $testDir/
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest schema validation failed"
+            exit 1
+          }
+          Write-Host "Manifest schema validation passed!"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,10 +1,10 @@
-name: Winget Publish
+name: Publish to Winget
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 0.1.123)'
+        description: 'Version to publish (e.g., 0.1.0)'
         required: true
         type: string
 
@@ -14,25 +14,102 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download checksums
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          $version = "${{ inputs.version }}"
-          $tag = "v$version"
-          gh release download $tag --pattern "checksums.txt" --dir artifacts
-
       - name: Install wingetcreate
+        shell: pwsh
         run: |
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      - name: Update and submit manifest
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --repo open-cli-collective/salesforce-cli --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/salesforce-cli" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate new"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           $version = "${{ inputs.version }}"
-          $baseUrl = "https://github.com/open-cli-collective/salesforce-cli/releases/download/v$version"
+          gh release download "v$version" --repo open-cli-collective/salesforce-cli --pattern "checksums.txt" --dir .
 
-          ./wingetcreate.exe update OpenCLICollective.salesforce-cli `
-            --version $version `
-            --urls "$baseUrl/sfdc_${version}_windows_amd64.zip|x64" "$baseUrl/sfdc_${version}_windows_arm64.zip|arm64" `
-            --submit `
-            --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $x64 = "https://github.com/open-cli-collective/salesforce-cli/releases/download/v$version/sfdc_${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/salesforce-cli/releases/download/v$version/sfdc_${version}_windows_arm64.zip"
+
+          Write-Host "Updating existing manifest to version $version"
+          ./wingetcreate.exe update OpenCLICollective.salesforce-cli --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.salesforce-cli.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.salesforce-cli.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.salesforce-cli.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          # Replace checksums one at a time using .NET regex (PowerShell -replace doesn't support count)
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
+          Set-Content "$manifestDir/OpenCLICollective.salesforce-cli.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir


### PR DESCRIPTION
## Summary

Aligns the CI/CD workflows with the patterns established in google-readonly.

## Changes

### New workflows
- **test-winget.yml** - Validates winget manifest schema on PR/push to `packaging/winget/**`
- **test-chocolatey.yml** - Tests full Chocolatey install/uninstall cycle on PR/push to `packaging/chocolatey/**`

### Updated workflows

**release.yml**
- Added `workflow_dispatch` support for manual triggering
- Added `continue-on-error: true` to chocolatey/winget jobs (so goreleaser success isn't blocked)
- Winget job now checks if manifest exists in winget-pkgs and uses `submit` for new packages

**winget-publish.yml**
- Added release validation step
- Added logic to handle both new and existing packages (update vs submit)

**chocolatey-publish.yml**
- Added release validation step
- Cleaned up PowerShell syntax

**auto-release.yml**
- Added `permissions: contents: write`
- Added `feat(` and `fix(` patterns (not just `feat:` and `fix:`)

## Test plan

- [ ] CI passes
- [ ] Trigger manual winget-publish workflow with v0.1.0 to test new package submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)