### PR TITLE
ci: remove path filtering from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - '.github/workflows/ci.yml'
   pull_request:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - '.github/workflows/ci.yml'
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Remove path filtering from CI so it runs on all PRs regardless of which files changed
- Matches the pattern used by hubspot-cli, google-readonly, newrelic-cli, and slack-chat-api
- Path filtering caused CI to silently skip on packaging/docs-only PRs, making results hard to interpret