### PR TITLE
ci: add linux-packages dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,3 +197,21 @@ jobs:
 
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token $env:WINGET_GITHUB_TOKEN $manifestDir
+
+  linux-packages:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Trigger linux-packages repo update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LINUX_PACKAGES_DISPATCH_TOKEN }}
+          repository: open-cli-collective/linux-packages
+          event-type: package-release
+          client-payload: |-
+            {
+              "package": "sfdc",
+              "version": "${{ github.ref_name }}",
+              "repo": "open-cli-collective/salesforce-cli"
+            }


### PR DESCRIPTION
## Summary

- Add `linux-packages` dispatch job to `release.yml`
- Triggers `open-cli-collective/linux-packages` `receive-package.yml` on each release
- Uses `continue-on-error: true` so dispatch failures do not block the release

Closes #39

## Test plan

- [ ] Merge and trigger a sfdc release
- [ ] Verify the dispatch fires and the package appears in the APT repo